### PR TITLE
Log CLI-Output in devMode

### DIFF
--- a/src/services/MJMLService.php
+++ b/src/services/MJMLService.php
@@ -96,8 +96,7 @@ class MJMLService extends Component
             
             // Log Cli output if in devMode
             if(Craft::$app->getConfig()->general->devMode){
-	        	Craft::info($message, 'superbig\mjml');   
-	        	die('Ende');
+	        	Craft::info($message, 'mjml');   
             }
         }
 

--- a/src/services/MJMLService.php
+++ b/src/services/MJMLService.php
@@ -92,7 +92,13 @@ class MJMLService extends Component
 
             $cmd = "$mjmlPath $tempPath -o $tempOutputPath";
 
-            $this->executeShellCommand($cmd);
+            $message = $this->executeShellCommand($cmd);
+            
+            // Log Cli output if in devMode
+            if(Craft::$app->getConfig()->general->devMode){
+	        	Craft::info($message, 'superbig\mjml');   
+	        	die('Ende');
+            }
         }
 
         $output = file_get_contents($tempOutputPath);


### PR DESCRIPTION
To help investigating errors I saves the CLI output to a variable and logged it when devMode is enabled:
            
```
$message = $this->executeShellCommand($cmd);

// Log Cli return if in devMode
if(Craft::$app->getConfig()->general->devMode){
	Craft::info($message, 'mjml');   
}
```

This helped me a lot and might help others as well.