### PR TITLE
Always render template if in LivePreview mode

### DIFF
--- a/src/services/MJMLService.php
+++ b/src/services/MJMLService.php
@@ -87,7 +87,7 @@ class MJMLService extends Component
         $tempPath       = Craft::$app->getPath()->getTempPath() . "/mjml/mjml-{$hash}.html";
         $tempOutputPath = Craft::$app->getPath()->getTempPath() . "/mjml/mjml-output-{$hash}.html";
 
-        if (!file_exists($tempOutputPath)) {
+        if (file_exists($tempOutputPath) == false or Craft::$app->request->isLivePreview()) {
             FileHelper::writeToFile($tempPath, $html);
 
             $cmd = "$mjmlPath $tempPath -o $tempOutputPath";

--- a/src/services/MJMLService.php
+++ b/src/services/MJMLService.php
@@ -87,7 +87,7 @@ class MJMLService extends Component
         $tempPath       = Craft::$app->getPath()->getTempPath() . "/mjml/mjml-{$hash}.html";
         $tempOutputPath = Craft::$app->getPath()->getTempPath() . "/mjml/mjml-output-{$hash}.html";
 
-        if (file_exists($tempOutputPath) == false or Craft::$app->request->isLivePreview()) {
+        if (file_exists($tempOutputPath) == false or Craft::$app->request->getIsPreview()) {
             FileHelper::writeToFile($tempPath, $html);
 
             $cmd = "$mjmlPath $tempPath -o $tempOutputPath";


### PR DESCRIPTION
In LivePreview mode, the template is not rendered again with every change, since there's already an output file existing.

This change makes sure that the template is rendered anew every time if in LivePreview.

Maybe there is a better or cleaner solution I am not aware of. But for now it fixes the problem.