### PR TITLE
Add CLI config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.5 - 2020-12-18
+### Added
+- Allow for optional CLI config settings (e.g. minify)
+
 ## 1.0.4 - 2020-04-01
 ### Fixed
 - Always render template if in LivePreview mode ([#11](https://github.com/superbigco/craft-mjml/pull/11))

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ return [
     // The path to where the MJML cli installed with npm is located, i.e. `/usr/local/bin/mjml`
     'mjmlCliPath'   => '',
 
+    // cli config args, e.g. `--config.minify true`',
+    'mjmlCliConfigArgs'   => '',
+
     // The app id received by email
     'appId'     => '',
 

--- a/src/config.php
+++ b/src/config.php
@@ -29,6 +29,9 @@ return [
     // The path to where the MJML cli installed with npm is located, i.e. `/usr/local/bin/mjml`
     'mjmlCliPath'   => '',
 
+    // cli config args, e.g. `--config.minify true`',
+    'mjmlCliConfigArgs'   => '',
+
     // The app id received by email
     'appId'     => '',
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -38,6 +38,11 @@ class Settings extends Model
     /**
      * @var string
      */
+    public $mjmlCliConfigArgs = '';
+
+    /**
+     * @var string
+     */
     public $appId = '';
 
     /**
@@ -54,7 +59,7 @@ class Settings extends Model
     public function rules()
     {
         return [
-            [['appId', 'secretKey', 'mjmlCliPath', 'nodePath'], 'string'],
+            [['appId', 'secretKey', 'mjmlCliPath', 'nodePath', 'mjmlCliConfigArgs'], 'string'],
             [['appId', 'secretKey'], 'required'],
         ];
     }

--- a/src/services/MJMLService.php
+++ b/src/services/MJMLService.php
@@ -84,13 +84,14 @@ class MJMLService extends Component
         $settings       = MJML::$plugin->getSettings();
         $mjmlPath       = "{$settings->nodePath} {$settings->mjmlCliPath}";
         $hash           = md5($html);
+        $configArgs     = "{$settings->mjmlCliConfigArgs}";
         $tempPath       = Craft::$app->getPath()->getTempPath() . "/mjml/mjml-{$hash}.html";
         $tempOutputPath = Craft::$app->getPath()->getTempPath() . "/mjml/mjml-output-{$hash}.html";
 
         if (file_exists($tempOutputPath) == false or Craft::$app->request->getIsPreview()) {
             FileHelper::writeToFile($tempPath, $html);
 
-            $cmd = "$mjmlPath $tempPath -o $tempOutputPath";
+            $cmd = "$mjmlPath $tempPath $configArgs -o $tempOutputPath";
 
             $message = $this->executeShellCommand($cmd);
             

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -50,3 +50,11 @@
     name: 'mjmlCliPath',
     value: settings['mjmlCliPath']})
 }}
+
+{{ forms.textField({
+    label: 'MJML cli config args',
+    instructions: 'Enter the (optional) cli config args, e.g. `--config.minify true`',
+    id: 'mjmlCliConfigArgs',
+    name: 'mjmlCliConfigArgs',
+    value: settings['mjmlCliConfigArgs']})
+}}


### PR DESCRIPTION
This PR implements a method to allow the user to set any CLI command line args they would want.

Being able to produce minified HTML output from the MJML CLI is a very valuable feature. Most people will probably want to be able to produce minified code, but there are a handful of other useful config options. Rather than hardcoding the config args in the code, this lets the developers control how they want it and makes it future proof for MJML CLI config releases (i.e. it does not make any assumptions about the available config options for the CLI version that's installed).

For reference, I have a newsletter email that is 150K without minification and it is reduced to 83K when minified. This prevents it from being clipped in Gmail and is just best practice for email clients.